### PR TITLE
Fix detail page Astro import error

### DIFF
--- a/interstellar-inclination/src/pages/[slug].astro
+++ b/interstellar-inclination/src/pages/[slug].astro
@@ -1,5 +1,4 @@
 ---
-import { Astro } from 'astro';
 const WP = import.meta.env.WP_URL;
 
 const slug = decodeURIComponent(Astro.params.slug || '');


### PR DESCRIPTION
## Summary
- remove unnecessary Astro import from blog detail page

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c6d6372b083309fbde58a5ab6d7d5